### PR TITLE
ProgressNotifier clearInterval on abort

### DIFF
--- a/src/lib/utils/streams/ProgressNotifier.ts
+++ b/src/lib/utils/streams/ProgressNotifier.ts
@@ -28,4 +28,9 @@ export class ProgressNotifier extends Transform {
     clearInterval(this.progressInterval);
     cb(null);
   }
+
+  _destroy(error: Error | null, cb: (error: Error | null) => void) {
+    clearInterval(this.progressInterval);
+    cb(error);
+  }
 }


### PR DESCRIPTION
## What

Currently, ProgressNotifier is sent with the stream and clears the interval when the connection successfully ends. However, when the connection is canceled, the flush function never executes, and the interval continues running.