### PR TITLE
Improve type in upload function

### DIFF
--- a/src/lib/core/upload/strategy.ts
+++ b/src/lib/core/upload/strategy.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 
-import { UploadOneStreamStrategyObject, UploadOneShardStrategyObject } from '.';
+import { UploadOneStreamStrategyObject, UploadOneShardStrategyObject, UploadOptions } from '.';
 import { Abortable, ActionState, ContractMeta } from '../../../api';
 import { ShardMeta } from '../../models';
 
@@ -14,7 +14,7 @@ export type UploadStrategyLabel = string;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type UploadStrategyObject = UploadOneStreamStrategyObject | UploadOneShardStrategyObject;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type UploadStrategyFunction = (bucketId: string, opts: any) => ActionState;
+export type UploadStrategyFunction = (bucketId: string, opts: UploadOptions) => ActionState;
 
 export abstract class UploadStrategy extends EventEmitter implements Abortable {
   fileEncryptionKey = Buffer.alloc(0);


### PR DESCRIPTION
## What

The uploadMultipartFile has this signature:
```ts
uploadMultipartFile(bucketId: string, opts: UploadOptions): ActionState;
```

However, the upload function had this signature:
```ts
type UploadStrategyFunction = (bucketId: string, opts: any) => ActionState;
```

This PR changes the types of `opts` from `any` to `UploadOptions` so we can pass the options with type safety.