### PR TITLE
Add app details to network

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internxt/inxt-js",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/api/EnvironmentConfig.ts
+++ b/src/api/EnvironmentConfig.ts
@@ -1,7 +1,10 @@
+import { AppDetails } from "@internxt/sdk/dist/shared";
+
 export interface EnvironmentConfig {
   bridgeUrl?: string;
   bridgeUser: string;
   bridgePass: string;
+  appDetails: AppDetails;
   encryptionKey?: string;
   logLevel?: number;
   inject?: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,10 +59,6 @@ export class Environment {
     return GetFileInfo(this.config, bucketId, fileId);
   }
 
-  static getFileInfo(bridgeUrl: string, bucketId: string, fileId: string, token: string): Promise<FileInfo> {
-    return GetFileInfo({ bridgeUrl, bridgePass: '', bridgeUser: '' }, bucketId, fileId, token);
-  }
-
   /**
    * Gets list of available buckets
    * @param cb Callback that will receive the list of buckets
@@ -237,6 +233,7 @@ export class Environment {
         user: this.config.bridgeUser,
         pass: this.config.bridgePass
       },
+      this.config.appDetails,
       opts.progressCallback,
       uploadState
     ).then((fileId) => {
@@ -298,6 +295,7 @@ export class Environment {
         user: this.config.bridgeUser,
         pass: this.config.bridgePass
       },
+      this.config.appDetails,
       opts.progressCallback,
       () => {
         opts.finishedCallback(null, stream);

--- a/src/lib/core/download/downloadV2.ts
+++ b/src/lib/core/download/downloadV2.ts
@@ -12,6 +12,7 @@ import { Events as ProgressEvents, HashStream, ProgressNotifier } from '../../ut
 import { DownloadProgressCallback } from '.';
 import Errors from './errors';
 import { ChunkSizeTransform } from '../../utils/streams/Chunker';
+import { AppDetails } from '@internxt/sdk/dist/shared';
 
 
 export function downloadFileV2(
@@ -20,6 +21,7 @@ export function downloadFileV2(
   mnemonic: string,
   bridgeUrl: string,
   creds: { pass: string, user: string },
+  appDetails: AppDetails,
   notifyProgress: DownloadProgressCallback,
   onV2Confirmed: () => void,
   abortController: AbortController,
@@ -27,8 +29,11 @@ export function downloadFileV2(
 ): [Promise<void>, PassThrough] {
   const outStream = new PassThrough();
   const network = Network.client(bridgeUrl, {
-    clientName: 'inxt-js',
-    clientVersion: '1.0'
+    ...appDetails,
+    customHeaders: {
+      lib: 'inxt-js',
+      ...appDetails.customHeaders,
+    }
   }, {
     bridgeUser: creds.user,
     userId: sha256(Buffer.from(creds.pass)).toString('hex')

--- a/src/lib/core/upload/uploadV2.ts
+++ b/src/lib/core/upload/uploadV2.ts
@@ -15,6 +15,7 @@ import Errors from '../download/errors';
 import { UploadProgressCallback } from '.';
 import { logger } from '../../utils/logger';
 import { uploadParts } from './multipart';
+import { AppDetails } from '@internxt/sdk/dist/shared';
 
 function putStream(url: string, fileSize?: number): Writable {
   const formattedUrl = new URL(url);
@@ -40,6 +41,7 @@ export function uploadFileV2(
   mnemonic: string,
   bridgeUrl: string,
   creds: { pass: string; user: string },
+  appDetails: AppDetails,
   notifyProgress: UploadProgressCallback,
   actionState: ActionState,
 ): Promise<string> {
@@ -52,8 +54,11 @@ export function uploadFileV2(
   const network = Network.client(
     bridgeUrl,
     {
-      clientName: 'inxt-js',
-      clientVersion: '1.0',
+      ...appDetails,
+      customHeaders: {
+        lib: 'inxt-js',
+        ...appDetails.customHeaders,
+      }
     },
     {
       bridgeUser: creds.user,


### PR DESCRIPTION
## What

Add appDetails into the upload and download functions so we can include the desktop header. We are going to be able to also include the clientName and clientVersion to identify the real client. Inside the custom headers we add also `lib: 'inxt-js'` so we can identify that the request is being made through inxt-js. This is breaking change, so, should I update version to `2.3.1` or how?