### PR TITLE
[PB-6237] Fix upload range error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/inxt-js",
   "author": "Internxt <hello@internxt.com>",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/lib/core/upload/multipart.ts
+++ b/src/lib/core/upload/multipart.ts
@@ -1,7 +1,7 @@
 import { queue } from 'async';
-import { Readable } from 'stream';
 import { logger } from '../../utils/logger';
 import { request } from 'undici';
+import { ProgressNotifier } from '../../utils/streams';
 
 type Part = { PartNumber: number; ETag: string };
 
@@ -31,14 +31,18 @@ interface PartUpload {
   source: { size: number; stream: Buffer; index: number };
 }
 
-export async function uploadParts(partUrls: string[], stream: Readable, signal?: AbortSignal): Promise<Part[]> {
+export async function uploadParts(
+  partUrls: string[],
+  progress: ProgressNotifier,
+  signal?: AbortSignal,
+): Promise<Part[]> {
   const parts: Part[] = [];
   const concurrency = 10;
 
   const partLength = 15 * 1024 * 1024;
   let bytesRead = 0;
   let partNumber = 1;
-  let partBuffer = Buffer.alloc(0);
+  let partChunks: Buffer[] = [];
 
   const uploadQueue = queue(async (part: PartUpload, callback) => {
     logger.debug('Uploading part %s of %s => %s bytes', part.source.index, partUrls.length, part.source.size);
@@ -56,16 +60,17 @@ export async function uploadParts(partUrls: string[], stream: Readable, signal?:
     }
   }, concurrency);
 
-  for await (const chunk of stream) {
+  for await (const chunk of progress) {
     bytesRead += chunk.length;
-    partBuffer = Buffer.concat([partBuffer, chunk]);
+    partChunks.push(chunk);
 
     while (uploadQueue.running() >= concurrency) {
       await uploadQueue.unsaturated();
     }
 
     while (bytesRead >= partLength) {
-      const slice = partBuffer.slice(0, partLength);
+      const partBuffer = Buffer.concat(partChunks);
+      const slice = partBuffer.subarray(0, partLength);
       uploadQueue.push({
         url: partUrls[partNumber - 1],
         source: {
@@ -75,13 +80,14 @@ export async function uploadParts(partUrls: string[], stream: Readable, signal?:
         },
       });
 
-      partBuffer = partBuffer.slice(partLength);
+      partChunks = [partBuffer.subarray(partLength)];
       bytesRead -= partLength;
       partNumber += 1;
     }
   }
 
   if (bytesRead > 0) {
+    const partBuffer = Buffer.concat(partChunks);
     uploadQueue.push({
       url: partUrls[partNumber - 1],
       source: {

--- a/src/lib/core/upload/uploadV2.ts
+++ b/src/lib/core/upload/uploadV2.ts
@@ -31,11 +31,8 @@ const crypto: Crypto = {
 async function putFile(url: string, body: Readable, fileSize: number, signal?: AbortSignal): Promise<void> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/octet-stream',
+    'Content-Length': fileSize.toString(),
   };
-
-  if (fileSize) {
-    headers['Content-Length'] = fileSize.toString();
-  }
 
   const { statusCode, body: responseBody } = await request(url, {
     method: 'PUT',


### PR DESCRIPTION
## What

A user had this error:

<img width="1591" height="325" alt="image" src="https://github.com/user-attachments/assets/6ecba71b-67f7-4c6c-bfd2-253b410ab0fb" />

And it was because we were creating a new buffer everytime with this line: `Buffer.concat([partBuffer, chunk]);`.

A new solution was proposed using Claude. I would like to say that I understand the solution in detail but I don't, since it's very specific of how the upload to the S3 is done. I've tested the solution from windows and it's not also that the multipart works, but I found a big improvement in the upload.