### PR TITLE
Multipart dump response body

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/inxt-js",
   "author": "Internxt <hello@internxt.com>",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/lib/core/upload/multipart.ts
+++ b/src/lib/core/upload/multipart.ts
@@ -20,6 +20,7 @@ async function uploadPart(
   });
 
   if (statusCode === 200) {
+    await body.dump();
     return headers.etag?.toString();
   }
 

--- a/src/lib/core/upload/uploadV2.ts
+++ b/src/lib/core/upload/uploadV2.ts
@@ -28,8 +28,8 @@ const crypto: Crypto = {
   randomBytes,
 };
 
-async function putFile(url: string, body: Readable, fileSize: number, signal?: AbortSignal): Promise<void> {
-  const headers: Record<string, string> = {
+export async function putFile(url: string, body: Readable, fileSize: number, signal?: AbortSignal): Promise<void> {
+  const headers = {
     'Content-Type': 'application/octet-stream',
     'Content-Length': fileSize.toString(),
   };
@@ -48,7 +48,7 @@ async function putFile(url: string, body: Readable, fileSize: number, signal?: A
   }
 }
 
-export function uploadFileV2(
+export async function uploadFileV2(
   network: Network,
   fileSize: number,
   source: Readable,
@@ -59,7 +59,7 @@ export function uploadFileV2(
 ): Promise<string> {
   let cipher: Cipheriv;
 
-  return uploadFile(
+  return await uploadFile(
     network,
     crypto,
     bucketId,
@@ -97,7 +97,7 @@ export function uploadFileV2(
   );
 }
 
-export function uploadFileMultipart(
+export async function uploadFileMultipart(
   network: Network,
   fileSize: number,
   source: Readable,
@@ -110,7 +110,7 @@ export function uploadFileMultipart(
   const partSize = 15 * 1024 * 1024;
   const parts = Math.ceil(fileSize / partSize);
 
-  return uploadMultipartFile(
+  return await uploadMultipartFile(
     network,
     crypto,
     bucketId,
@@ -151,7 +151,7 @@ export function uploadFileMultipart(
   );
 }
 
-export function upload(
+export async function upload(
   fileSize: number,
   source: Readable,
   bucketId: string,
@@ -184,8 +184,8 @@ export function upload(
   });
 
   if (fileSize > MULTIPART_THRESHOLD) {
-    return uploadFileMultipart(network, fileSize, source, bucketId, mnemonic, progress, abortSignal);
+    return await uploadFileMultipart(network, fileSize, source, bucketId, mnemonic, progress, abortSignal);
   }
 
-  return uploadFileV2(network, fileSize, source, bucketId, mnemonic, progress, abortSignal);
+  return await uploadFileV2(network, fileSize, source, bucketId, mnemonic, progress, abortSignal);
 }


### PR DESCRIPTION
## What

When doing multipart uploads we were not removing the response body so it was staying in memory until (I assume) the garbage collector was removing it. This was causing that for a file of 10GB the memory was increasing from 600MB to 1400MB with just 10% uploaded. This `dump()` was already applied in the normal `upload` but not in the `multipartUpload`. Now, I understand more the `upload` process and I think it will be a good idea in the near future to replace the `async` module with `p-limit` since the implementation is much more simple.