### PR TITLE
Fix: handle part error upload on uploadParts function

### DIFF
--- a/src/lib/core/upload/multipart.ts
+++ b/src/lib/core/upload/multipart.ts
@@ -44,24 +44,25 @@ export async function uploadParts(
   let bytesRead = 0;
   let partNumber = 1;
   let partChunks: Buffer[] = [];
+  let uploadPartError: Error | null = null;
 
-  const uploadQueue = queue(async (part: PartUpload, callback) => {
+  const uploadQueue = queue(async (part: PartUpload) => {
     logger.debug('Uploading part %s of %s => %s bytes', part.source.index, partUrls.length, part.source.size);
 
-    try {
-      const etag = await uploadPart(part.url, part.source, signal);
+    const etag = await uploadPart(part.url, part.source, signal);
 
-      if (!etag) {
-        throw new Error('ETag header was not returned');
-      }
-      parts.push({ PartNumber: part.source.index, ETag: etag });
-      callback();
-    } catch (err) {
-      callback(err as Error);
+    if (!etag) {
+      throw new Error('ETag header was not returned');
     }
+    parts.push({ PartNumber: part.source.index, ETag: etag });
   }, concurrency);
 
+  uploadQueue.error((err) => {
+    uploadPartError = err;
+  });
+
   for await (const chunk of progress) {
+    if (uploadPartError) break;
     bytesRead += chunk.length;
     partChunks.push(chunk);
 
@@ -87,7 +88,7 @@ export async function uploadParts(
     }
   }
 
-  if (bytesRead > 0) {
+  if (bytesRead > 0 && !uploadPartError) {
     const partBuffer = Buffer.concat(partChunks);
     uploadQueue.push({
       url: partUrls[partNumber - 1],
@@ -99,8 +100,12 @@ export async function uploadParts(
     });
   }
 
-  while (uploadQueue.running() > 0 || uploadQueue.length() > 0) {
+  while (!uploadPartError && (uploadQueue.running() > 0 || uploadQueue.length() > 0)) {
     await uploadQueue.drain();
+  }
+
+  if (uploadPartError) {
+    throw uploadPartError;
   }
 
   return parts.sort((pA, pB) => pA.PartNumber - pB.PartNumber);

--- a/src/lib/core/upload/multipart.ts
+++ b/src/lib/core/upload/multipart.ts
@@ -62,7 +62,7 @@ export async function uploadParts(
   });
 
   for await (const chunk of progress) {
-    if (uploadPartError) break;
+    if (uploadPartError) throw uploadPartError;
     bytesRead += chunk.length;
     partChunks.push(chunk);
 

--- a/tests/lib/core/upload/multipart.test.ts
+++ b/tests/lib/core/upload/multipart.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, beforeEach, expect, vi } from 'vitest';
+import { Readable } from 'stream';
+import { request } from 'undici';
+import { uploadParts } from '../../../../src/lib/core/upload/multipart';
+import { ProgressNotifier } from '../../../../src/lib/utils/streams/ProgressNotifier';
+
+vi.mock('undici');
+
+const mockRequest = vi.mocked(request);
+
+function makeProgress(): ProgressNotifier {
+  const progress = new ProgressNotifier(1024);
+  Readable.from(Buffer.alloc(1024, 'a')).pipe(progress);
+  return progress;
+}
+
+describe('multipart', () => {
+  const partUrls = ['http://fake-s3.com/part-1'];
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe('uploadParts', () => {
+    it('should return all parts sorted by PartNumber when upload succeeds', async () => {
+      const etag = '"etag-1"';
+      mockRequest.mockResolvedValue({
+        statusCode: 200,
+        headers: { etag },
+        body: { dump: vi.fn().mockResolvedValue(undefined) },
+      } as unknown as Awaited<ReturnType<typeof request>>);
+
+      const parts = await uploadParts(partUrls, makeProgress(), new AbortController().signal);
+
+      expect(parts).toStrictEqual([{ PartNumber: 1, ETag: etag }]);
+    });
+
+    it('should throw when a part fails to upload', async () => {
+      mockRequest.mockResolvedValue({
+        statusCode: 500,
+        headers: {},
+        body: { text: vi.fn().mockResolvedValue('Internal Server Error') },
+      } as unknown as Awaited<ReturnType<typeof request>>);
+
+      await expect(uploadParts(partUrls, makeProgress(), new AbortController().signal)).rejects.toThrow(
+        'Failed to upload part: 500',
+      );
+    });
+  });
+});


### PR DESCRIPTION
While testing in the office on a slow connection on drive desktop linux, when uploading a 2.2GB file failed with this error:

```
header: 'E - b -     '
msg: '[ETFUF ERROR]'
error: Error: Size does not match. Expected: 2199497034, Got: 1648994634
```

**Doing the math**: at 15MB per part as per [uploadParts partLength](https://github.com/internxt/inxt-js/blob/master/src/lib/core/upload/multipart.ts#L43), a 2.2GB file needs 140 parts. it  only uploaded 105, leaving 550MB missing. The upload completed without throwing when it should have failed the moment a part failed to be uploaded.

I found out that async [internally wraps async worker functions](https://github.com/caolan/async/blob/v3.2.6/lib/queue.js#L146-L151) through [wrapAsync](https://github.com/caolan/async/blob/v3.2.6/lib/internal/wrapAsync.js#L15-L18) and [asyncify](https://github.com/caolan/async/blob/v3.2.6/lib/asyncify.js#L62-L67). I have seen that `asyncify` is not really passing the callback to the worker but instead passing it into `handlePromise`, which wires it directly to the workers promise: rejections call `cb(err)`, which is what triggers `uploadQueue.error()`. So the trycatch and manual callback are not needed .So there is no need to wrap into trycatch and just add the `uploadQueue.error()` handler instead

What happened before is that the callback parameter in the worker was always undefined. Every call to `callback()` or `callback(err)`  we got callback is not a function. I found out about this while doing the `it('should throw when a part fails to upload', async () => {` test.
Also `handlePromise` inside `asyncify` was catching the exception and tried to route it to  `uploadQueue.error()`  but since there was no such handler registered, the error was being discarded, causing that the original error `(Failed to upload part:` from [uploadPart](https://github.com/internxt/inxt-js/blob/master/src/lib/core/upload/multipart.ts#L27) was not being handled. 
