### PR TITLE
Fix: restore tryCatch inside the worker in multipart queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/inxt-js",
   "author": "Internxt <hello@internxt.com>",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/inxt-js",
   "author": "Internxt <hello@internxt.com>",
-  "version": "3.0.6",
+  "version": "3.0.5",
   "description": "",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/lib/core/upload/multipart.ts
+++ b/src/lib/core/upload/multipart.ts
@@ -46,15 +46,19 @@ export async function uploadParts(
   let partChunks: Buffer[] = [];
   let uploadPartError: Error | null = null;
 
-  const uploadQueue = queue(async (part: PartUpload) => {
+  const uploadQueue = queue(async (part: PartUpload, callback) => {
     logger.debug('Uploading part %s of %s => %s bytes', part.source.index, partUrls.length, part.source.size);
+    try {
+      const etag = await uploadPart(part.url, part.source, signal);
 
-    const etag = await uploadPart(part.url, part.source, signal);
-
-    if (!etag) {
-      throw new Error('ETag header was not returned');
+      if (!etag) {
+        throw new Error('ETag header was not returned');
+      }
+      parts.push({ PartNumber: part.source.index, ETag: etag });
+      callback();
+    } catch (err) {
+      callback(err as Error);
     }
-    parts.push({ PartNumber: part.source.index, ETag: etag });
   }, concurrency);
 
   uploadQueue.error((err) => {

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -8,13 +8,11 @@ export default defineConfig({
     coverage: {
       provider: 'istanbul',
       reporter: ['text', 'lcov'],
-      exclude: [
-        'test/',
-        'dist/',
-        '**/*types.ts',
-        ...coverageConfigDefaults.exclude
-      ],
+      exclude: ['test/', 'dist/', '**/*types.ts', ...coverageConfigDefaults.exclude],
     },
-    restoreMocks: true
-  }
+    restoreMocks: true,
+  },
+  oxc: {
+    target: 'es2015',
+  },
 });


### PR DESCRIPTION
**TL;DR:** Restoring the try/catch + callback() in the multipart queue worker, and fixing the vitest config so tests transpile async the same way the production build does. Without the config fix, tests take a different code path than prod and hide the real bug.

In https://github.com/internxt/inxt-js/pull/121 I removed the `callback()` from the worker while making the [`it('should throw when a part fails to upload'...` ](https://github.com/internxt/inxt-js/blob/master/tests/lib/core/upload/multipart.test.ts#L38)for the `multiparts` upload function as it was giving me the following error (you can see it as well [here](https://github.com/internxt/inxt-js/actions/runs/24606371044/job/71953173351?pr=123))

```bash
FAIL  tests/lib/core/upload/multipart.test.ts > multipart > uploadParts > should throw when a part fails to upload
AssertionError: expected [Function] to throw error including 'Failed to upload part: 500' but got 'callback is not a function'

Expected: "Failed to upload part: 500"
Received: "callback is not a function"
```
As I stated on #121
> I found out that async [internally wraps async worker functions](https://github.com/caolan/async/blob/v3.2.6/lib/queue.js#L146-L151) through [wrapAsync](https://github.com/caolan/async/blob/v3.2.6/lib/internal/wrapAsync.js#L15-L18) and [asyncify](https://github.com/caolan/async/blob/v3.2.6/lib/asyncify.js#L62-L67). I have seen that asyncify is not really passing the callback to the worker but instead passing it into handlePromise, which wires it directly to the workers promise: rejections call cb(err), which is what triggers uploadQueue.error(). So the trycatch and manual callback are not needed .So there is no need to wrap into trycatch and just add the uploadQueue.error() handler instead

This assumption is partially true, while the library does wrap workers like that, on different targets such as ours [ `"target": "es5"`](https://github.com/internxt/inxt-js/blob/master/tsconfig.json#L5C3-L5C23) async [cannot detect properly async functions as statet in their docs](https://caolan.github.io/async/v3/global.html#:~:text=Note%2C%20due%20to,returns%20a%20promise.)
The root cause was that vitest was not actually testing on the same target as the /build target (on the first commit of this pull request you can see that the tests are not passing exactly because of that) so tests took the `asyncify` code path while the actual `/build` code took the callback path.