### PR TITLE
Fix premature close

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/inxt-js",
   "author": "Internxt <hello@internxt.com>",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/lib/core/upload/uploadV2.ts
+++ b/src/lib/core/upload/uploadV2.ts
@@ -78,12 +78,12 @@ export async function uploadFileV2(
       const hasher = new HashStream();
       const relayStream = new PassThrough();
 
+      const putFilePromise = putFile(url, relayStream, fileSize, abortSignal);
       const pipelinePromise = pipeline(source, cipher, hasher, progress, relayStream, {
         signal: abortSignal,
       });
 
-      await putFile(url, relayStream, fileSize, abortSignal);
-      await pipelinePromise;
+      await Promise.all([pipelinePromise, putFilePromise]);
 
       const fileHash = hasher.getHash().toString('hex');
 


### PR DESCRIPTION
## What

Some users were getting this error:

```
[2026-04-23 16:15:24.244] {
  header: 'E - b - sync',
  msg: 'Failed to upload file to the bucket',
  path: 'W:/InternxtDrive - a11c2841-9c78-4981-90ca-640f9e2d1abe/Backup Pixel/.SeedVaultAndroidBackup/92e518490a039364c14697a78e403283039ba36f83c2281bec454bae320b13fd/cd/cddf836fe667afdd02df0fb231e04d5c5dd31c1fea3e8cb3eb8e08b069887f0e',
  error: Error: Premature close
      at PassThrough.<anonymous> (node:internal/streams/pipeline:422:29)
      at PassThrough.emit (node:events:520:35)
      at emitCloseNT (node:internal/streams/destroy:148:10)
      at processTicksAndRejections (node:internal/process/task_queues:89:21) {
    code: 'ERR_STREAM_PREMATURE_CLOSE',
    context: { bucketId: 'ea11ce48d5a1d9efd46ffed5', fileSize: 36925, user: 'berichtnaar@pm.me', crypto: {} }
  }
```

This happened because there was a race condition between the stream pipeline and the HTTP PUT request. Previously, the upload request could finish and close the PassThrough stream before pipeline() had fully completed, especially for small files. The fix runs both the upload and pipeline concurrently using Promise.all, ensuring the stream remains open until all data has been flushed correctly.