### PR TITLE
Fix tsconfig target

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@internxt/inxt-js",
   "author": "Internxt <hello@internxt.com>",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,6 @@ type GetBucketsCallback = (err: Error | null, result: any) => void;
 
 type GetBucketIdCallback = (err: Error | null, result: any) => void;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-type DeleteBucketCallback = (err: Error | null, result: any) => void;
-
 type ListFilesCallback = (err: Error | null, result: any) => void;
 
 type DeleteFileCallback = (err: Error | null, result: any) => void;
@@ -144,10 +141,6 @@ export class Environment {
   listFiles(bucketId: string, cb: ListFilesCallback): void {
     /* TODO */
     cb(Error('Not implemented yet'), null);
-  }
-
-  setEncryptionKey(newEncryptionKey: string): void {
-    this.config.encryptionKey = newEncryptionKey;
   }
 
   upload: UploadStrategyFunction = async (bucketId: string, opts: UploadOptions) => {
@@ -264,10 +257,6 @@ export class Environment {
   };
 
   downloadCancel(state: ActionState): void {
-    state.stop();
-  }
-
-  uploadCancel(state: ActionState): void {
     state.stop();
   }
 

--- a/src/lib/INXTRequest.ts
+++ b/src/lib/INXTRequest.ts
@@ -1,10 +1,8 @@
 import { ClientRequest } from 'http';
 import { EventEmitter } from 'events';
-import { Readable } from 'stream';
-import axios, { AxiosRequestConfig, AxiosResponse, Canceler } from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 
-import { request, streamRequest } from '../services/request';
-import { ProxyManager, getProxy } from '../services/proxy';
+import { request } from '../services/request';
 import { EnvironmentConfig } from '../api';
 
 export enum Methods {
@@ -18,18 +16,11 @@ export enum Methods {
 export class INXTRequest extends EventEmitter {
   private req: Promise<any> | ClientRequest | undefined;
   private config: EnvironmentConfig;
-  private cancel: Canceler;
   private useProxy: boolean;
-  private streaming = false;
 
   method: Methods;
   targetUrl: string;
   params: AxiosRequestConfig;
-
-  static Events = {
-    UploadProgress: 'upload-progress',
-    DownloadProgress: 'download-progress',
-  };
 
   constructor(
     config: EnvironmentConfig,
@@ -45,14 +36,11 @@ export class INXTRequest extends EventEmitter {
     this.targetUrl = targetUrl;
     this.useProxy = useProxy ?? false;
     this.params = params;
-
-    this.cancel = () => null;
   }
 
   start<K>(): Promise<K> {
     // TODO: Abstract from axios
     const source = axios.CancelToken.source();
-    this.cancel = source.cancel;
 
     const cancelToken = source.token;
 
@@ -65,68 +53,5 @@ export class INXTRequest extends EventEmitter {
     ).then<JSON>((res) => res.data);
 
     return this.req;
-  }
-
-  async stream<K>(content: Readable, size: number): Promise<AxiosResponse<K>>;
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async stream<K>(): Promise<Readable>;
-  async stream<K>(content?: any, size?: number): Promise<any> {
-    if (size) {
-      return this.postStream<K>(content, size);
-    }
-
-    return this.getStream();
-  }
-
-  private async getStream(): Promise<Readable> {
-    this.streaming = true;
-
-    let proxy: ProxyManager | undefined;
-
-    if (this.useProxy) {
-      proxy = await getProxy();
-    }
-
-    const targetUrl = `${proxy && proxy.url ? proxy.url + '/' : ''}${this.targetUrl}`;
-
-    return streamRequest(targetUrl);
-  }
-
-  private async postStream<K>(content: Readable, size: number): Promise<K> {
-    this.streaming = true;
-
-    let proxy: ProxyManager | undefined;
-
-    if (this.useProxy) {
-      proxy = await getProxy();
-    }
-
-    const targetUrl = `${proxy && proxy.url ? proxy.url + '/' : ''}${this.targetUrl}`;
-
-    return axios
-      .post<K>(targetUrl, content, {
-        maxContentLength: Infinity,
-        headers: {
-          'Content-Type': 'application/octet-stream',
-          'Content-Length': size.toString(),
-        },
-      })
-      .then((res) => {
-        proxy?.free();
-
-        return res as unknown as K;
-      });
-  }
-
-  abort() {
-    if (this.streaming && this.req instanceof ClientRequest) {
-      return this.req.destroy();
-    }
-
-    this.cancel();
-  }
-
-  isCancelled(err: Error): boolean {
-    return axios.isCancel(err);
   }
 }

--- a/src/lib/core/upload/multipart.ts
+++ b/src/lib/core/upload/multipart.ts
@@ -46,19 +46,14 @@ export async function uploadParts(
   let partChunks: Buffer[] = [];
   let uploadPartError: Error | null = null;
 
-  const uploadQueue = queue(async (part: PartUpload, callback) => {
+  const uploadQueue = queue(async (part: PartUpload) => {
     logger.debug('Uploading part %s of %s => %s bytes', part.source.index, partUrls.length, part.source.size);
-    try {
-      const etag = await uploadPart(part.url, part.source, signal);
+    const etag = await uploadPart(part.url, part.source, signal);
 
-      if (!etag) {
-        throw new Error('ETag header was not returned');
-      }
-      parts.push({ PartNumber: part.source.index, ETag: etag });
-      callback();
-    } catch (err) {
-      callback(err as Error);
+    if (!etag) {
+      throw new Error('ETag header was not returned');
     }
+    parts.push({ PartNumber: part.source.index, ETag: etag });
   }, concurrency);
 
   uploadQueue.error((err) => {

--- a/src/services/request.ts
+++ b/src/services/request.ts
@@ -1,8 +1,6 @@
-import * as url from 'url';
 import * as https from 'https';
 import * as http from 'http';
 import { Readable } from 'stream';
-import { ClientRequest, IncomingMessage } from 'http';
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 import { EnvironmentConfig } from '../api';
@@ -42,61 +40,6 @@ export async function request(
     }
 
     return value;
-  });
-}
-
-export function streamRequest(targetUrl: string, timeoutSeconds?: number): Readable {
-  const uriParts = url.parse(targetUrl);
-  let downloader: ClientRequest | null = null;
-
-  function _createDownloadStream(): ClientRequest {
-    const requestOpts = {
-      protocol: uriParts.protocol,
-      hostname: uriParts.hostname,
-      port: uriParts.port,
-      path: uriParts.path,
-      headers: {
-        Accept: 'application/octet-stream',
-      },
-    };
-
-    return uriParts.protocol === 'http:' ? http.get(requestOpts) : https.get(requestOpts);
-  }
-
-  return new Readable({
-    read() {
-      if (!downloader) {
-        downloader = _createDownloadStream();
-
-        if (timeoutSeconds) {
-          downloader.setTimeout(timeoutSeconds * 1000, () => {
-            downloader?.destroy(Error(`Request timeouted after ${timeoutSeconds} seconds`));
-          });
-        }
-
-        this.once('signal', (message: string) => {
-          if (message === 'Destroy request') {
-            downloader?.destroy();
-          }
-
-          this.destroy();
-        });
-
-        downloader
-          .on('response', (res: IncomingMessage) => {
-            res
-              .on('data', this.push.bind(this))
-              .on('error', this.emit.bind(this, 'error'))
-              .on('end', () => {
-                this.push.bind(this, null);
-                this.emit('end');
-              })
-              .on('close', this.emit.bind(this, 'close'));
-          })
-          .on('error', this.emit.bind(this, 'error'))
-          .on('timeout', () => this.emit('error', Error('Request timeout')));
-      }
-    },
   });
 }
 

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -12,7 +12,4 @@ export default defineConfig({
     },
     restoreMocks: true,
   },
-  oxc: {
-    target: 'es2015',
-  },
 });


### PR DESCRIPTION
## What

There was an issue in the current version when uploading multipart files. This happened because an issue @AlexisMora found in the `async` library about accepting a callback or not. The problem happened because in this PR the `tsconfig target` was changed: https://github.com/internxt/inxt-js/pull/129/changes#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0R3, but in the tests it was still running with old one. So the tests were passing but the multipart upload of the build was broken.

Now, we have removed the callback and the old target in the tests. Now, the tests run and the multipart upload works in the built version. So, the version `3.1.1` is currently broken. @larryrider @AlexisMora 

I've also deleted some code that was not used anywhere (it came from a private function with 0 references).