### PR TITLE
feat: send internxt-client/internxt-version headers on Bridge requests

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,13 @@
 import { EnvironmentConfig } from '../api';
 import { INXTRequest, Methods } from '../lib';
 
+const { version: packageVersion } = require('../../package.json');
+
+const clientHeaders = {
+  'internxt-client': 'inxt-js',
+  'internxt-version': packageVersion,
+};
+
 export interface CreateFileTokenResponse {
   bucket: string;
   encryptionKey: string;
@@ -40,30 +47,42 @@ export class Bridge extends InxtApi {
   createFileToken(bucketId: string, fileId: string, operation: 'PUSH' | 'PULL'): INXTRequest {
     const targetUrl = `${this.config.bridgeUrl}/buckets/${bucketId}/tokens`;
 
-    return new INXTRequest(this.config, Methods.Post, targetUrl, { data: { operation, file: fileId } }, false);
+    return new INXTRequest(
+      this.config,
+      Methods.Post,
+      targetUrl,
+      { data: { operation, file: fileId }, headers: clientHeaders },
+      false,
+    );
   }
 
   renameFile(bucketId: string, fileId: string, newName: string): INXTRequest {
     const targetUrl = `${this.config.bridgeUrl}/buckets/${bucketId}/files/${fileId}`;
 
-    return new INXTRequest(this.config, Methods.Patch, targetUrl, { data: { name: newName } });
+    return new INXTRequest(this.config, Methods.Patch, targetUrl, {
+      data: { name: newName },
+      headers: clientHeaders,
+    });
   }
 
   createBucket(bucketName: string) {
     const targetUrl = `${this.config.bridgeUrl}/buckets`;
 
-    return new INXTRequest(this.config, Methods.Post, targetUrl, { data: { name: bucketName } });
+    return new INXTRequest(this.config, Methods.Post, targetUrl, {
+      data: { name: bucketName },
+      headers: clientHeaders,
+    });
   }
 
   deleteBucket(bucketId: string) {
     const targetUrl = `${this.config.bridgeUrl}/buckets/${bucketId}`;
 
-    return new INXTRequest(this.config, Methods.Delete, targetUrl, {});
+    return new INXTRequest(this.config, Methods.Delete, targetUrl, { headers: clientHeaders });
   }
 
   getDownloadLinks(bucketId: string, fileIds: string[]) {
     const targetUrl = `${this.config.bridgeUrl}/buckets/${bucketId}/bulk-files?fileIds=${fileIds.join(',')}`;
 
-    return new INXTRequest(this.config, Methods.Get, targetUrl, {});
+    return new INXTRequest(this.config, Methods.Get, targetUrl, { headers: clientHeaders });
   }
 }


### PR DESCRIPTION
## What

Adds the `internxt-client: inxt-js` and `internxt-version: <package version>` headers to every request made by `Bridge` in `src/services/api.ts` (`createFileToken`, `renameFile`, `createBucket`, `deleteBucket`, `getDownloadLinks`).

## Why

These bridge requests were not sending any client identification headers, so the bridge server had no way to identify the calling client or its version.

## Test plan
- [x] `yarn type-check`
- [x] `yarn lint`
- [x] `yarn test`